### PR TITLE
Fix selection of device in evaluate.py

### DIFF
--- a/evaluate.py
+++ b/evaluate.py
@@ -143,7 +143,7 @@ def viz_map_array(maps, labels, n_col=8, subsample=4, max_figures=-1):
 
 
 def evaluate(model, test_loader):
-    model.to('cuda')
+    model.to(c.device)
     model.eval()
     if not c.pre_extracted:
         fe = FeatureExtractor()


### PR DESCRIPTION
Function evaluate could only be used in GPU setting. This minor fix permits to use it accordingly to the parameter "device" of config.py