### PR TITLE
Extend Score_Observer to every starting epoch

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -164,7 +164,7 @@ class Score_Observer:
 
     def update(self, score, epoch, print_score=False):
         self.last = score
-        if epoch == 0 or score > self.max_score:
+        if self.max_score == None or score > self.max_score:
             self.max_score = score
             self.max_epoch = epoch
         if print_score:


### PR DESCRIPTION
If the starting epoch of the training is different from 0, Score_Observer throws an error. This can be problematic if we want to resume training. This simple fix makes Score_Observer independent from the number of the starting epoch